### PR TITLE
Support for unicode, xmerl handles it

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Saml.Mixfile do
   def project do
     [
       app: :saml,
-      version: "0.1.1",
+      version: "0.1.2",
       elixir: "~> 1.7",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Got SAML with UTF-8 encoded data in a field. Failed XML parsing because of invalid character. The combo of `Base64.decode` and `String.to_charlist` produced a list of unicode codepoints. `xmlerl` wants a list of bytes that match the xml prolog, which is often `utf-8`. Re-encoding to bytes is more problematic than just using the built-in base64 lib to decode.